### PR TITLE
Fix Stranger in a Strange Land quest marker

### DIFF
--- a/files/scripts/mapdata-skellige.js
+++ b/files/scripts/mapdata-skellige.js
@@ -1619,7 +1619,7 @@ window.mapdata_skellige = {
 		label: $.t("sidequests.label.therapy"),
 		popup: $.t("sidequests.desc.therapy")
 	},{
-		coords: [[-61.100,-37.770]],
+		coords: [[-62.278,-36.321]],
 		label: $.t("sidequests.label.stranger") + '*',
 		popup: $.t("misc.active",{quest: $.t("contracts.label.eldberg")}) + $.t("sidequests.desc.stranger")
 	},{


### PR DESCRIPTION
The marker is in the wrong location. I moved it here:
![stranger](https://user-images.githubusercontent.com/186443/232905754-05e8fda6-990e-4a41-a4e2-c2440076e179.png)

But technically the quests first pops up during the fighting in the Arinbjorn Inn. See here:
https://www.youtube.com/watch?v=AjKeU9RMG7k
So maybe it should be moved to that Inn?