### PR TITLE
Add Honeycomb toggle to Skellige

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Desctiption
+Description
 --------------------------------------
 It is an enhanced version of the work published by [untamed0](https://github.com/untamed0).
 I have released version 3.5 as an intermediate version upon popular demand. I'll post updates as development progresses.

--- a/s/index.html
+++ b/s/index.html
@@ -49,7 +49,7 @@
 					<li><i class="herbalist"></i><div data-i18n="sidebar.herbalist">Herbalist</div></li>
 					<li><i class="hidden"></i><div data-i18n="sidebar.hidden">Hidden Treasure</div></li>
 					<li><i class="hollow"></i><div data-i18n="sidebar.hollow">Hollow Treasure</div></li>
-					<!--<li><i class="honeycomb"></i><div data-i18n="sidebar.honeycomb">Honeycomb</div></li>-->
+					<li><i class="honeycomb"></i><div data-i18n="sidebar.honeycomb">Honeycomb</div></li>
 					<li><i class="innkeep"></i><div data-i18n="sidebar.innkeep">Innkeep</div></li>
 					<!--<li><i class="kid"></i><div data-i18n="sidebar.kid">Knight in Distress</div></li>-->
 					<li><i class="monsterden"></i><div data-i18n="sidebar.monsterden">Monster Den</div></li>
@@ -67,7 +67,6 @@
 					<li><i class="spoils"></i><div data-i18n="sidebar.spoils">Spoils of War</div></li>
 					<li><i class="treasure"></i><div data-i18n="sidebar.treasure">Treasure</div></li>
 					<!--<li><i class="vineyardinfestation"></i><div data-i18n="sidebar.vineyardinfestation">Vineyard Infestation</div></li>-->
-					<li class="none"></li>
 				</ul>
 				<ul class="key controls">
 					<li id="show-all"><i class="fa fa-eye"></i><div data-i18n="controls.show">Show All</div></li>


### PR DESCRIPTION
The Honeycomb toggle was missing in the sidebar of the Skellige map. This PR adds the toggle.

Also a small README typo fix.